### PR TITLE
Use `getBy`, not `queryBy`, to fail on missing element

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,17 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "sompylasar",
+      "name": "Ivan Babak",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/498274?v=4",
+      "profile": "https://sompylasar.github.io",
+      "contributions": [
+        "code",
+        "ideas"
+      ]
     }
-  ]
+  ],
+  "repoType": "github"
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![downloads][downloads-badge]][npmtrends]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Code of Conduct][coc-badge]][coc]
 
@@ -74,8 +74,8 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 
 <!-- prettier-ignore -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/cypress-testing-library/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/cypress-testing-library/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/cypress-testing-library/commits?author=kentcdodds "Tests") |
-| :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/cypress-testing-library/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/cypress-testing-library/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/cypress-testing-library/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/498274?v=4" width="100px;"/><br /><sub><b>Ivan Babak</b></sub>](https://sompylasar.github.io)<br />[💻](https://github.com/kentcdodds/cypress-testing-library/commits?author=sompylasar "Code") [🤔](#ideas-sompylasar "Ideas, Planning, & Feedback") |
+| :---: | :---: |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/add-commands.js
+++ b/src/add-commands.js
@@ -1,6 +1,6 @@
 import {commands} from './'
 
-commands.forEach(({command, name}) => {
+commands.forEach(({name, command}) => {
   Cypress.Commands.add(name, command)
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,17 @@
 import {queries} from 'dom-testing-library'
 
 const commands = Object.keys(queries)
-  .filter(queryName => queryName.startsWith('query'))
+  .filter(queryName => queryName.startsWith('getBy'))
   .map(queryName => {
-    const commandName = queryName.replace(/^query/, 'get')
     return {
-      name: commandName,
+      name: queryName,
       command: (...args) => {
         const fn = new Function(
           'args',
           'query',
           'getCommandWaiter',
           `
-            return function Command__${commandName}({document}) {
+            return function Command__${queryName}({document}) {
               return getCommandWaiter(document, () => query(document, ...args))();
             };
           `,


### PR DESCRIPTION
BREAKING CHANGE: The queries will now throw a useful message and fail
the test if the queried element is missing.