### PR TITLE
chore(deps): Allow Cypress 3 within peerDep. Updated Cypress and serve deps

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
   "baseUrl": "http://localhost:13370",
-  "videoRecording": false,
-  "screenshotOnHeadlessFailure": false
+  "video": false
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm-run-all --parallel test:unit test:cypress",
     "test:unit": "kcd-scripts test --no-watch",
     "test:unit:watch": "kcd-scripts test",
-    "test:cypress:serve": "serve --clipless --local --port 13370 ./cypress/fixtures/test-app",
+    "test:cypress:serve": "serve -l 13370 ./cypress/fixtures/test-app",
     "test:cypress:run": "cypress run",
     "test:cypress:open": "cypress open",
     "test:cypress": "npm-run-all --silent --parallel --race test:cypress:serve test:cypress:run",
@@ -42,13 +42,13 @@
     "dom-testing-library": "^2.0.0"
   },
   "devDependencies": {
-    "cypress": "^2.1.0",
+    "cypress": "^3.0.1",
     "kcd-scripts": "^0.37.0",
     "npm-run-all": "^4.1.2",
-    "serve": "^6.5.6"
+    "serve": "^7.2.0"
   },
   "peerDependencies": {
-    "cypress": "^2.1.0"
+    "cypress": "^2.1.0 || ^3.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
**Why**:

Cypress 3 has been released on 5/29/2018 ([changelog](https://docs.cypress.io/guides/references/changelog.html)).

**What**:

* Updated `peerDependencies` to allow Cypress 3
* Updated Cypress within the `devDependencies`
* Updated serve within the `devDependencies`
* Changed configs and scripts accordingly.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation (N/A)
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

Locally, I'm having an issue with `npm run validate` not exiting. Everything passes, but the process doesn't exit. Curious to see if it also happens in Travis.
