### PR TITLE
upgrade dom-testing-library

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ const jestConfig = require('kcd-scripts/jest')
 
 module.exports = Object.assign(jestConfig, {
   testEnvironment: 'jest-environment-jsdom',
+  testURL: 'http://localhost/',
 })

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "dom-testing-library": "^2.0.0"
+    "dom-testing-library": "^3.4.0"
   },
   "devDependencies": {
     "cypress": "^3.0.1",
     "kcd-scripts": "^0.37.0",
     "npm-run-all": "^4.1.2",
-    "serve": "^7.2.0",
+    "serve": "^10.0.0",
     "wait-port": "^0.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
**What**:

- Upgrade `dom-testing-library`
- Upgrade `serve`, mainly because it was printing a warning about a newer version.
- In the process I added a jest config setting without which I got weird errors. See [this](https://stackoverflow.com/a/51554619/621809) for details. Not sure why it has not been an issue for others so far.

**Why**:

The main motivation was upgrading `dom-testing-library` just to keep it up to date with the latest and greatest.

**How**:

By updating the dependency version numbers in `package.json`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->