### PR TITLE
docs: Add link to Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## The problem
 
-You want to use [`dom-testing-library`][dom-testing-library] methods in your [Cypress](https://www.cypress.io/) tests.
+You want to use [`dom-testing-library`][dom-testing-library] methods in your [Cypress][cypress] tests.
 
 ## This solution
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## The problem
 
-You want to use [`dom-testing-library`][dom-testing-library] methods in your Cypress tests.
+You want to use [`dom-testing-library`][dom-testing-library] methods in your [Cypress](https://www.cypress.io/) tests.
 
 ## This solution
 
@@ -132,3 +132,4 @@ MIT
 [emojis]: https://github.com/kentcdodds/all-contributors#emoji-key
 [all-contributors]: https://github.com/kentcdodds/all-contributors
 [dom-testing-library]: https://github.com/kentcdodds/dom-testing-library
+[cypress]: https://www.cypress.io/


### PR DESCRIPTION
**What**:

Add link to Cypress in `README`.

**Why**:

Might be helpful for people that : 
- don't know what Cypress is. 
- are familiar with `kcd-testing-libraries` testing style but not Cypress.
- are looking for quick link to Cypress to browse docs.

**Checklist**:

* [x] Documentation
* [ ] Tests *N/A*
* [x] Ready to be merged
* [ ] Added myself to contributors table *N/A Too small a change to consider myself a contributor 😄* 

Please feel free to ignore this PR for any reason !
Cheers !