### PR TITLE
WIP: chore(typescript): add TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:cypress:dev": "npm-run-all --silent --parallel --race test:cypress:serve test:cypress:open",
     "validate": "kcd-scripts validate build,lint,test",
     "setup": "npm install && npm run validate -s",
-    "precommit": "kcd-scripts precommit"
+    "precommit": "kcd-scripts precommit",
+    "dtslint": "dtslint typings"
   },
   "files": [
     "dist",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "cypress": "^3.0.1",
+    "dtslint": "^0.3.0",
     "kcd-scripts": "^0.37.0",
     "npm-run-all": "^4.1.2",
     "serve": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "Simple and complete custom Cypress commands and utilities that encourage good testing practices.",
   "main": "dist/index.js",
+  "typings": "typings",
   "engines": {
     "node": "> 6"
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,37 @@
-declare namespace Cypress {
-  interface Chainable<Subject = any> {
-    getByTestId<S = string>(x: string): Chainable<S>
+// TypeScript Version: 2.8
+import {
+  SelectorMatcherOptions,
+  Matcher,
+  MatcherOptions,
+  getByTestId,
+} from 'dom-testing-library'
+
+export namespace Cypress {
+  type GetByAttribute = (id: Matcher, options?: MatcherOptions) => Chainable
+
+  type QueryByText = (
+    id: Matcher,
+    options?: SelectorMatcherOptions,
+  ) => Chainable
+
+  type AllByText = (id: Matcher, options?: SelectorMatcherOptions) => Chainable
+
+  type GetByText = (id: Matcher, options?: SelectorMatcherOptions) => Chainable
+
+  interface Chainable {
+    getByPlaceholderText: GetByAttribute
+    queryByText: QueryByText
+    queryAllByText: AllByText
+    getByText: GetByText
+    getAllByText: AllByText
+    queryByLabelText: QueryByText
+    queryAllByLabelText: AllByText
+    getByLabelText: GetByText
+    getAllByLabelText: AllByText
+    getByAltText: GetByAttribute
+    getByTestId: GetByAttribute
+    getByTitle: GetByAttribute
+    getByValue: GetByAttribute
+    getByTRole: GetByAttribute
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,5 @@
+declare namespace Cypress {
+  interface Chainable<Subject = any> {
+    getByTestId<S = string>(x: string): Chainable<S>
+  }
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "noEmit": true,
+
+    "baseUrl": ".",
+    "paths": {"cypress-testing-library": ["."]}
+  }
+}

--- a/typings/tslint.json
+++ b/typings/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "semicolon": [true, "never"],
+    "whitespace": [false]
+  }
+}


### PR DESCRIPTION
**What**: Attempts to fix #12. I've only added support for `getByTestId` to ensure that I've done things correctly. I wonder if there's an easy way to keep up to date with `dom-testing-library`?

**Why**: For TypeScript support

**How**: Added a `typings` directory and added a reference to `package.json`.

I've tried to copy how cypress adds its own types for chainable methods and custom commands: https://github.com/cypress-io/add-cypress-custom-command-in-typescript/blob/master/README.md

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation: add instructions on adding the library types to tsconfig.json
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
