### PR TITLE
Add tests to verify error messages thrown by commands

### DIFF
--- a/cypress/integration/commands.spec.js
+++ b/cypress/integration/commands.spec.js
@@ -3,8 +3,7 @@ describe('dom-testing-library commands', () => {
     cy.visit('/')
   })
   it('getByPlaceholderText', () => {
-    cy
-      .getByPlaceholderText('Placeholder Text')
+    cy.getByPlaceholderText('Placeholder Text')
       .click()
       .type('Hello Placeholder')
   })
@@ -14,8 +13,7 @@ describe('dom-testing-library commands', () => {
   })
 
   it('getByLabelText', () => {
-    cy
-      .getByLabelText('Label For Input Labelled By Id')
+    cy.getByLabelText('Label For Input Labelled By Id')
       .click()
       .type('Hello Input Labelled By Id')
   })
@@ -38,17 +36,35 @@ describe('dom-testing-library commands', () => {
   })
 
   it('getByText within', () => {
-    cy.get('#nested')
-      .within(() => {
-        cy.getByText('Button Text').click()
-      })
+    cy.get('#nested').within(() => {
+      cy.getByText('Button Text').click()
+    })
   })
 
   it('getByText in container', () => {
-    cy.get('#nested')
-      .then((subject) => {
-        cy.getByText('Button Text', { container: subject }).click()
-      })
+    cy.get('#nested').then(subject => {
+      cy.getByText('Button Text', {container: subject}).click()
+    })
+  })
+
+  it('getByTestId only throws the error message', () => {
+    const testId = 'Some random id'
+    const errorMessage = `Unable to find an element by: [data-testid="${testId}"]`
+    cy.on('fail', err => {
+      expect(err.message).to.eq(errorMessage)
+    })
+
+    cy.getByTestId(testId).click()
+  })
+
+  it('getByText only throws the error message', () => {
+    const text = 'Some random text'
+    const errorMessage = `Unable to find an element with the text: ${text}. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.`
+    cy.on('fail', err => {
+      expect(err.message).to.eq(errorMessage)
+    })
+
+    cy.getByText('Some random text').click()
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
       "import/prefer-default-export": "off",
-      "import/no-unassigned-import": "off"
+      "import/no-unassigned-import": "off",
+      "jest/valid-expect": "off"
     }
   },
   "eslintIgnore": [


### PR DESCRIPTION
This PR adds tests to verify [this issue](https://github.com/kentcdodds/dom-testing-library/issues/156) I added in https://github.com/kentcdodds/dom-testing-library

This PR is intended to fail.
When the issue at dom-testing-library resolves and the dependency is updated with a new release, this test should pass.

* [ ] Documentation
* [x] Tests
* [ ] Ready to be merged 
* [ ] Added myself to contributors table 
